### PR TITLE
Remove old lighthouse dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,7 +160,6 @@ RUN npm i -g node-sass@4.10.0 --unsafe-perm=true
 RUN npm i -g optipng-bin@5.0.0 --unsafe-perm=true
 RUN npm i -g jpegtran-bin@4.0.0 --unsafe-perm=true
 RUN npm i -g gifsicle@4.0.1 --unsafe-perm=true
-RUN npm i -g lighthouse --unsafe-perm=true
 RUN npm i -g @lhci/cli@0.3.x --unsafe-perm=true
 
 # Set command-line version of PHP to preferred version


### PR DESCRIPTION
Closes #8 and will trigger re-build in DockerHub to fix issues with Deployer where their site was down yesterday.