### PR TITLE
Develop to master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,17 +103,17 @@ RUN curl -LO https://phar.phpunit.de/phpunit-7.phar \
     && mv phpunit-7.phar /usr/local/bin/phpunit \
     && chmod +x /usr/local/bin/phpunit
 
-# Install Codeception
+# Install Codeception (backwards compatibility)
 
-# RUN curl -LO https://codeception.com/codecept.phar \
-#     && mv codecept.phar /usr/local/bin/codecept \
-#     && chmod +x /usr/local/bin/codecept
+RUN curl -LO https://codeception.com/codecept.phar \
+    && mv codecept.phar /usr/local/bin/codecept \
+    && chmod +x /usr/local/bin/codecept
 
 # Set command-line version of PHP to preferred version
 
 RUN update-alternatives --set php /usr/bin/php$PHP_VERSION
 
-# Install Codeception
+# Install Codeception via Composer
 
 RUN composer global require codeception/codeception \
     && composer global require codeception/module-asserts \

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,13 +105,19 @@ RUN curl -LO https://phar.phpunit.de/phpunit-7.phar \
 
 # Install Codeception
 
-RUN curl -LO https://codeception.com/codecept.phar \
-    && mv codecept.phar /usr/local/bin/codecept \
-    && chmod +x /usr/local/bin/codecept
+# RUN curl -LO https://codeception.com/codecept.phar \
+#     && mv codecept.phar /usr/local/bin/codecept \
+#     && chmod +x /usr/local/bin/codecept
 
 # Set command-line version of PHP to preferred version
 
 RUN update-alternatives --set php /usr/bin/php$PHP_VERSION
+
+# Install Codeception
+
+RUN composer global require codeception/codeception \
+    && composer global require codeception/module-asserts \
+    && composer global require codeception/module-phpbrowser
 
 # Install AWS SDK PHP globally via Composer
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# PHP Craft
+
+PHP Craft is a Docker image used to build, test and deploy Craft CMS and Laravel sites within a CI environment.
+
+:warning: This image is not designed to be compact, it to packages everything we need into a single image. Please see the Dockerfile for the exact contents.
+
+## Contributing
+
+All commits / pull requests should be made to the develop branch. This will build automatically within DockerHub to the develop Docker tag.
+
+Once tested, develop should be merged into master. A release then needs to be made off of master with the version number incrementing from the previous (e.g. `v1.2.0` :arrow_right: `v1.2.1`). DockerHub will build this tag and the latest branch will be re-built to match the master branch.


### PR DESCRIPTION
Install Codeception via Composer as well as through the phar install. Eventually we will remove the phar install, however for the moment it needs to stay for backwards compatibility.